### PR TITLE
Fix a couple bugs and add an "overwrite" feature for s3 module

### DIFF
--- a/windows/win_s3.py
+++ b/windows/win_s3.py
@@ -47,6 +47,12 @@ options:
     required: yes
     default: null
     aliases: []
+  overwrite:
+    description:
+      - If true, download the file or directory even if it already exists on the host.
+    required: no
+    default: false
+    aliases: []
   method:
     description:
       - S3 method to carry out. Upload: upload file or entire directory to s3. Download: download a file or directory from s3.
@@ -100,6 +106,7 @@ $ ansible -i hosts -m win_s3 -a "bucket=apps key=My/Web/APP/ local=C:\Users\Me\W
       bucket: 'app_deploys'
       key: 'app/latest/Application.zip'
       method: 'download'
+      overwrite: true
       local: 'C:\Applications\\'
       access_key: 'EXAMPLECRED'
       secret_key: 'EXAMPLESECRET'

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -33,7 +33,7 @@ If ($params.src) {
         Fail-Json $result "src file: $src does not exist."
     }
 
-    $ext = [System.IO.Path]::GetExtension($dest)
+    $ext = [System.IO.Path]::GetExtension($src)
 }
 Else {
     Fail-Json $result "missing required argument: src"


### PR DESCRIPTION
Bug 1:  Unzip wasn't working for zip files.  `$dest` was being used to parse out extension instead of `$src`.  

Bug 2:  `Test-S3Bucket` was failing because AWS credentials were not set yet.  Moved setting credentials above the test.

New feature:  Add "overwrite" attribute for s3 module.  Allows downloading the file even if it exists already.  (I needed this for deploying an updated version of a file.)
